### PR TITLE
Validate limit price upon intent creation

### DIFF
--- a/afp/validators.py
+++ b/afp/validators.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 from binascii import Error
 from eth_typing.evm import ChecksumAddress
@@ -41,3 +42,15 @@ def validate_address(value: str) -> ChecksumAddress:
         return Web3.to_checksum_address(value)
     except ValueError:
         raise ValueError(f"{value} is not a valid blockchain address")
+
+
+def validate_limit_price(
+    value: Decimal, tick_size: int, rounding: str | None = None
+) -> Decimal:
+    if rounding is None:
+        num_fractional_digits = abs(int(value.normalize().as_tuple().exponent))
+        if num_fractional_digits > tick_size:
+            raise ValueError(
+                f"Limit price {value} can have at most {tick_size} fractional digits"
+            )
+    return value.quantize(Decimal("10") ** -tick_size, rounding=rounding)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,4 +1,6 @@
+import decimal
 from datetime import datetime, UTC
+from decimal import Decimal
 
 import pytest
 
@@ -45,3 +47,25 @@ def test_validate_hexstr32__pass():
 def test_validate_hexstr32__error(value):
     with pytest.raises(ValueError):
         validators.validate_hexstr32(value)
+
+
+def test_validate_limit_price__pass():
+    assert str(validators.validate_limit_price(Decimal("1.25"), 2)) == "1.25"
+    assert str(validators.validate_limit_price(Decimal("1.25"), 4)) == "1.2500"
+
+
+def test_validate_limit_price__rounding():
+    assert (
+        str(validators.validate_limit_price(Decimal("1.25"), 1, decimal.ROUND_DOWN))
+        == "1.2"
+    )
+
+
+def test_validate_limit_price__error():
+    with pytest.raises(ValueError):
+        validators.validate_limit_price(Decimal("1.25"), 1)
+
+
+def test_validate_limit_price__invalid_rounding_mode():
+    with pytest.raises(TypeError):
+        validators.validate_limit_price(Decimal("1.25"), 1, "foobar")


### PR DESCRIPTION
Make sure that the number of decimals in the fractional part of the limit price is not greater than the product's tick size. If needed, add the right number of trailing zeros to have exactly the required number of digits before the order is sent to the exchange.

Also add a `rounding` argument to `create_intent`; if specified it rounds the limit price to the required number of decimals instead of raising error.

Resolves #11.