### PR TITLE
Add pagination parameters to listing functions

### DIFF
--- a/afp/constants.py
+++ b/afp/constants.py
@@ -8,6 +8,7 @@ def _int_or_none(value: str | None) -> int | None:
 
 
 USER_AGENT = "afp-sdk/{}".format(metadata.version("afp-sdk"))
+DEFAULT_BATCH_SIZE = 50
 DEFAULT_EXCHANGE_API_VERSION = 1
 
 # Constants from clearing/contracts/lib/constants.sol

--- a/afp/exchange.py
+++ b/afp/exchange.py
@@ -16,6 +16,7 @@ from .exceptions import (
 from .schemas import (
     ExchangeParameters,
     ExchangeProduct,
+    ExchangeProductFilter,
     ExchangeProductListingSubmission,
     ExchangeProductUpdateSubmission,
     LoginSubmission,
@@ -52,8 +53,12 @@ class ExchangeClient:
         return ExchangeParameters(**response.json())
 
     # GET /products
-    def get_approved_products(self) -> list[ExchangeProduct]:
-        response = self._send_request("GET", "/products")
+    def get_approved_products(
+        self, filter: ExchangeProductFilter
+    ) -> list[ExchangeProduct]:
+        response = self._send_request(
+            "GET", "/products", params=filter.model_dump(exclude_none=True)
+        )
         return [ExchangeProduct(**item) for item in response.json()["products"]]
 
     # GET /products/{product_id}

--- a/afp/schemas.py
+++ b/afp/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from decimal import Decimal
 from functools import partial
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import inflection
 from pydantic import (
@@ -39,6 +39,33 @@ class Model(BaseModel):
     # Change the default value of by_alias to True
     def model_dump_json(self, by_alias: bool = True, **kwargs: Any) -> str:
         return super().model_dump_json(by_alias=by_alias, **kwargs)
+
+
+class PaginationFilter(Model):
+    batch: Annotated[None | int, Field(gt=0, exclude=True)]
+    batch_size: Annotated[None | int, Field(gt=0, exclude=True)]
+    newest_first: Annotated[None | bool, Field(exclude=True)]
+
+    @computed_field
+    @property
+    def page(self) -> None | int:
+        return self.batch
+
+    @computed_field
+    @property
+    def page_size(self) -> None | int:
+        return self.batch_size
+
+    @computed_field
+    @property
+    def sort(self) -> None | Literal["ASC", "DESC"]:
+        match self.newest_first:
+            case None:
+                return None
+            case True:
+                return "DESC"
+            case False:
+                return "ASC"
 
 
 # Authentication
@@ -79,6 +106,10 @@ class ExchangeProduct(Model):
         return self.id
 
 
+class ExchangeProductFilter(PaginationFilter):
+    pass
+
+
 class IntentData(Model):
     trading_protocol_id: str
     product_id: str
@@ -107,11 +138,11 @@ class Order(Model):
     intent: Intent
 
 
-class OrderFilter(Model):
+class OrderFilter(PaginationFilter):
     intent_account_id: str
     product_id: None | Annotated[str, AfterValidator(validators.validate_hexstr32)]
     type: None | OrderType
-    states: list[OrderState] = Field(exclude=True)
+    states: Annotated[list[OrderState], Field(exclude=True)]
     side: None | OrderSide
     start: None | Timestamp
     end: None | Timestamp
@@ -153,13 +184,13 @@ class OrderFill(Model):
     price: Decimal
 
 
-class OrderFillFilter(Model):
+class OrderFillFilter(PaginationFilter):
     intent_account_id: str
     product_id: None | Annotated[str, AfterValidator(validators.validate_hexstr32)]
     intent_hash: None | Annotated[str, AfterValidator(validators.validate_hexstr32)]
     start: None | Timestamp
     end: None | Timestamp
-    trade_states: list[TradeState] = Field(exclude=True)
+    trade_states: Annotated[list[TradeState], Field(exclude=True)]
 
     @computed_field
     @property

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,4 +1,4 @@
-from afp.schemas import Model
+from afp.schemas import Model, PaginationFilter
 
 
 class Person(Model):
@@ -15,3 +15,17 @@ def test_schema_aliasing__from_json():
 def test_schema_aliasing__to_json():
     person = Person(first_name="Foo", last_name="Bar")
     assert person.model_dump_json() == '{"firstName":"Foo","lastName":"Bar"}'
+
+
+def test_pagination_parameters__conversion():
+    filter = PaginationFilter(batch=2, batch_size=20, newest_first=False)
+    assert filter.model_dump() == {
+        "page": 2,
+        "page_size": 20,
+        "sort": "ASC",
+    }
+
+
+def test_pagination_parameters__null_values():
+    filter = PaginationFilter(batch=None, batch_size=None, newest_first=None)
+    assert filter.model_dump(exclude_none=True) == {}


### PR DESCRIPTION
Add `batch`, `batch_size` and `newest_first` arguments to `Trading.products()`, `Trading.orders()` and `Trading.order_fills()` that control how many results the functions return and in which order.